### PR TITLE
Fixed #163. Elasticsearch mappings and event creation is made using only...

### DIFF
--- a/app/models/elasticsearch_mapping_template.rb
+++ b/app/models/elasticsearch_mapping_template.rb
@@ -36,7 +36,7 @@ class ElasticsearchMappingTemplate
       }
     }
 
-    Manifest.all.each do |manifest|
+    Manifest.valid.each do |manifest|
       mappings["event_#{manifest.id}"] = {
         'dynamic_templates' => build_dynamic_templates_for(manifest),
         'properties' => build_properties_mapping_for(manifest),

--- a/app/models/events_schema.rb
+++ b/app/models/events_schema.rb
@@ -144,7 +144,7 @@ class EventsSchema
 
   def all_assay_names
     #TODO This should be AssayName.all
-    assay_names = Manifest.all.collect do |manifest|
+    assay_names = Manifest.valid.collect do |manifest|
       assay_mapping = manifest.flat_mappings.detect do |mapping|
         mapping["target_field"] == "assay_name"
       end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -12,6 +12,10 @@ class Manifest < ActiveRecord::Base
 
   NULL_STRING = "null"
 
+  CURRENT_VERSION = "1.1.0"
+
+  scope :valid, -> { where(api_version: CURRENT_VERSION) }
+
   EVENT_TEMPLATE = {
     "event" => {"indexed" => Hash.new, "pii" => Hash.new, "custom" => Hash.new},
     "sample" => {"indexed" => Hash.new, "pii" => Hash.new, "custom" => Hash.new},
@@ -160,8 +164,8 @@ class Manifest < ActiveRecord::Base
   end
 
   def check_api_version
-    unless self.metadata["api_version"].try(:starts_with?, "1.1")
-      self.errors.add(:api_version, "must be 1.1.x")
+    unless self.metadata["api_version"] == CURRENT_VERSION
+      self.errors.add(:api_version, "must be #{CURRENT_VERSION}")
     end
   end
 

--- a/spec/models/manifest_creation_spec.rb
+++ b/spec/models/manifest_creation_spec.rb
@@ -60,17 +60,33 @@ describe Manifest do
         "field_mapping" : {}
       }}
 
-      Manifest.create!(definition: definition)
+      Manifest.new(definition: definition).save(:validate => false)
 
       manifest = Manifest.first
 
       manifest.api_version.should eq('1.1.0')
       manifest.definition = updated_definition
-      manifest.save!
+      manifest.save(:validate => false)
 
       Manifest.count.should eq(1)
       DeviceModel.count.should eq(1)
       Manifest.first.api_version.should eq("1.1.1")
+    end
+
+    it "returns all the valid manifests" do
+      Manifest.new(definition: %{{
+        "metadata" : {
+          "device_models" : ["foo"],
+          "api_version" : "0.1.1",
+          "version" : 1,
+          "source" : {"type" : "json"}
+        },
+        "field_mapping" : {}
+      }}).save(:validate => false)
+
+      manifest = Manifest.create!(definition: definition)
+
+      Manifest.valid.should eq([manifest])
     end
 
     it "reuses an existing device model if it already exists" do
@@ -143,7 +159,5 @@ describe Manifest do
       Manifest.first.device_models.first.should eq(DeviceModel.first)
       DeviceModel.first.name.should eq("foo")
     end
-
   end
-
 end

--- a/spec/models/manifest_validations_spec.rb
+++ b/spec/models/manifest_validations_spec.rb
@@ -88,6 +88,18 @@ describe Manifest do
       m.errors[:metadata].first.should eq("must include api_version field")
     end
 
+    it "checks the version number against the current api version" do
+      expect {Manifest.create!(definition: %{{
+        "metadata" : {
+          "device_models" : ["foo"],
+          "api_version" : "1.1.1",
+          "version" : 1,
+          "source" : {"type" : "json"}
+        },
+        "field_mapping" : {}
+      }})}.to raise_error("Validation failed: Api version must be 1.1.0")
+    end
+
     it "shouldn't pass validations if metadata doesn't include device_models" do
       definition = %{{
         "metadata" : {
@@ -352,7 +364,5 @@ describe Manifest do
       Manifest.count.should eq(0)
       m.errors[:enum_fields].first.should eq("must be provided with options. (In 'results[*].result'")
     end
-
   end
-
 end


### PR DESCRIPTION
... the manifests that match the current api version number.